### PR TITLE
Remove wrapping square brackets from the logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Hugo  [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re) [<img src="hugo-logo-wide.svg" align="right" width="250">]
+# Awesome Hugo  [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re) <img src="hugo-logo-wide.svg" align="right" width="250">
 
 A curated list of awesome things related to Hugo, The world's fastest framework for building websites.
 


### PR DESCRIPTION
Before the commit [`"Remove errant link"`](https://github.com/budparr/awesome-hugo/commit/aedac7bca67b0b4b86b51d90f895caafffab9482), there were no brackets on the title.

Markdown syntax for linking to some URL is like `[text](url)`. At the commit `(url)` part was gone, but brackets of `[text]` were not. That is why weird-looking square brackets are displayed.