### PR TITLE
Add hugo-redirector to Theme components

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Hugo is a general-purpose website framework—written in Go—that generates sta
 - [hugo-notice](https://github.com/martignoni/hugo-notice) - A Hugo theme component to display nice notices.
 - [hugo-loremipsum](https://github.com/martignoni/hugo-loremipsum) - A Hugo theme component to generate Lorem ipsum.
 - [hugo-social-metadata](https://github.com/msfjarvis/hugo-social-metadata) - A Hugo theme component to generate social metadata.
+- [hudo-redirector](https://github.com/gcc42/hugo-redirector) - A Hugo theme component to automate redirection on Hugo sites (with SEO best practices).
 
 ## Projects using Hugo
 


### PR DESCRIPTION
I created the `hugo-redirector` component today to quickly add redirection on Hugo sites in a declarative way. 

This is similar to [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) for Hugo.