### PR TITLE
Add Hugo theme component (shortcode) hugo-github-calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Hugo is a general-purpose website framework—written in Go—that generates sta
 - [hugo-social-metadata](https://github.com/msfjarvis/hugo-social-metadata) - A Hugo theme component to generate social metadata.
 - [hudo-redirect](https://github.com/gcc42/hugo-redirect) - A Hugo theme component to setup URL redirections/aliasing on Hugo sites.
 - [hugo-cite](https://github.com/loup-brun/hugo-cite) - A Hugo theme component which uses CSL-JSON to create (academic) bibliography sections for pages and posts.
-- [hugo-responsive-images](https://github.com/future-wd/hugo-responsive-images) - A theme component for generating responsive images with srcset tags. Supports lazysizes for automatic sizes property and lazyloading polyfill.
+- [hugo-responsive-images](https://github.com/future-wd/hugo-responsive-images) - A Hugo theme component for generating responsive images with srcset tags. Supports lazysizes for automatic sizes property and lazyloading polyfill.
+- [hugo-github-calendar](https://github.com/totoroot/hugo-github-calendar) - A Hugo theme component for creating a graph of your GitHub contributions.
 
 ## Projects using Hugo
 


### PR DESCRIPTION
Adds a new Hugo theme component (shortcode), which I have written and actively maintain.

It uses modified templates from [github-calendar.js](https://github.com/Bloggify/github-calendar) to generate a graph of ones recent GitHub contributions.

The shortcode allows for convenient customization of the graph.